### PR TITLE
서버의 page 시작 지점과 프론트의 page 시작 지점을 통일

### DIFF
--- a/todo-react-app/src/App.js
+++ b/todo-react-app/src/App.js
@@ -61,12 +61,12 @@ function App() {
   };
 
   const componentDidmount = () => {
-    call("/todo?page=" + page + "&size=4", "GET", null).then((response) => {
+    call(`/todo?page=${page}&size=4`, "GET", null).then((response) => {
       setItems(response.data); // update State
-      setCountItem(response.error);
+      setCountItem(Number(response.error));
       setIsLoading(false);
       console.log(response.data);
-      console.log("get todo from server");
+      console.log("get todo from server ",`/todo?page=${page}&size=4`);
     });
   };
 

--- a/todo-spring-app/src/main/java/com/example/todospringapp/repository/TodoRepository.java
+++ b/todo-spring-app/src/main/java/com/example/todospringapp/repository/TodoRepository.java
@@ -14,5 +14,5 @@ public interface TodoRepository extends JpaRepository<TodoEntity, String> {
 
     List<TodoEntity> findAllByDone(boolean done);
 
-    Page<TodoEntity> findAllByUserIdOrderById(String userId, Pageable pageable);
+    Page<TodoEntity> findAllByUserIdOrderByDoneAsc(String userId, Pageable pageable);
 }

--- a/todo-spring-app/src/main/java/com/example/todospringapp/service/TodoService.java
+++ b/todo-spring-app/src/main/java/com/example/todospringapp/service/TodoService.java
@@ -27,7 +27,7 @@ public class TodoService {
     }
 
     public Page<TodoEntity> getTodoPage(final String userId, Pageable pageable) {
-        return todoRepository.findAllByUserIdOrderById(userId, pageable);
+        return todoRepository.findAllByUserIdOrderByDoneAsc(userId, pageable);
     }
 
     public List<TodoEntity> retrieve(final String userId) {

--- a/todo-spring-app/src/main/resources/application.yml
+++ b/todo-spring-app/src/main/resources/application.yml
@@ -1,5 +1,9 @@
 
 spring:
+  data:
+    web:
+      pageable:
+        one-indexed-parameters: true
   datasource:
     url: jdbc:h2:~/test
     driver-class-name: org.h2.Driver


### PR DESCRIPTION
## 문제상황
- 페이지의 Todo보다 적게 입력했을 때, 초기 화면은 서버에 page=0을 요청하여 적절한 Todo를 불러오지만, 프론트의 page 1을 누르면 page=1을 요청하여 서버 입장에서는 데이터가 없는 다음 페이지를 요청한 것이 되어 아무것도 표시되지 않는다.

### 해결방법
- pagable의 시작을 1로 변경하여 page=1로 요청 받았을 때 첫 페이지(page=0)를 응답한다.  